### PR TITLE
Fixing leaked globals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ var Spawn = require('child_process').spawn;
  * @param {Function} __callback__
  */
 function CronTab(u, cb) {
-    var self   = this;
+    var self   = this,
         user   = u || '',
         root   = (process.getuid() == 0),
         backup = {lines:[], jobs:[]},


### PR DESCRIPTION
Looks like a simple mistake of ; instead of ,.
