### PR TITLE
npm conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules
 test/test.js
 test/examples.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
     "version": "0.3.2",
     "main": "./lib/index",
     "dependencies": {},
+    "devDependencies": {
+        "vows": "0.7.0"
+    },
+    "scripts": {
+        "test": "test/runner.js"
+    },
     "engines": { "node": ">= 0.6.0" },
     "author": {
         "name"  : "Blagovest Dachev",


### PR DESCRIPTION
- Add `node_modules/` to `.gitnignore` so that git doesn't but you when you install packages with `npm install`.
- Add `vows` to `devDependencies` so that `npm install` installs it for you before you try to run `npm test`.
- Add `test/runner.js` as `npm test` script, the standard way to run Node tests.
