### PR TITLE
Pushing .jshintignore up to ~/.jshintignore

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
This `.jshintignore` is so general to JavaScript code that it would be better used as a global in `~/.jshintignore`.
