### PR TITLE
Being able to create a job from an cron expression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,6 +168,7 @@ function CronTab(u, cb) {
      *         tab.create('ls -l /');
      *         tab.create('ls -l /', 'just a silly example');
      *         tab.create('ls -l /', 'just a silly example', future);
+     *         tab.create('ls -l /', 'just a silly example', '* * * * *');
      *     });
      *
      * @param {String} __command__
@@ -179,7 +180,7 @@ function CronTab(u, cb) {
         var args    = Array.prototype.slice.call(arguments);
         var types   = args.map(function(arg) { return typeof arg; });
         var comment = (types[1] == 'string') ? args[1] : null;
-        var job     = makeJob(null, command, comment);
+        var job     = makeJob(args.length > 2 && types[2] == 'string' ? args[2] : null, command, comment);
         
         if (job == null) { return job; }
         


### PR DESCRIPTION
CronJob is not exported so there was no way to create a job directly from a cron expression.
