### PR TITLE
order the argument for easier sudo management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ require('crontab').load(function(err, crontab) {
 });
 ```
 
+### Sudoers
+
+If a user is specified, it is guaranteed that crontab will place the user argument first.
+This allows you to easily manage your sudoers file while using crontab.
+
+```sudoers
+MYUSER MYHOST=(root) crontab -u $user
+```
+
 ## Copyright
 Copyright 2010-2014, Blagovest Dachev.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -398,7 +398,7 @@ function CronTab(u, cb) {
     var args    = [actions[action]];
     
     if (user) {
-      args = args.concat('-u', user);
+      args = ['-u', user].concat(args);
     }
     
     return args;

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,8 +54,8 @@ var _     = require('underscore');
  */
 function CronTab(u, cb) {
   var self   = this;
-  var user   = typeof u === 'object' ? u && u.user : u || '';
-  var Spawn  = typeof u === 'object' ? u.spawn : SPAWN;
+  var user   = u && typeof u === 'object' ? u && u.user : u || '';
+  var Spawn  = u && typeof u === 'object' ? u.spawn : SPAWN;
   var backup = {lines:[], jobs:[]};
   var lines  = [];
   var jobs   = [];
@@ -481,22 +481,7 @@ function CronJob(line, c, m) {
   this.isValid = function() {
     return valid;
   }
-  /**
-   * Renders the object to a string as it would be written to the system.
-   * 
-   * Examples:
-   *     new CronTab(function(err, tab) {
-   *         if (err) { console.log(err); process.exit(1); }
-   *         
-   *         var jobs = tab.jobs({command:'ls -l /'});
-   *         for (var i = 0; i < jobs.length; i++) {
-   *             console.log(jobs[i].render());
-   *         }
-   *     });
-   *
-   * @return {String}
-   */
-  this.render = function() {
+  this.when = function () {
     var time = '';
     
     if (special) {
@@ -519,6 +504,26 @@ function CronJob(line, c, m) {
     if (timeIdx >=0 ) {
       time = '@' + keys[timeIdx];
     }
+
+    return time;
+  }
+  /**
+   * Renders the object to a string as it would be written to the system.
+   * 
+   * Examples:
+   *     new CronTab(function(err, tab) {
+   *         if (err) { console.log(err); process.exit(1); }
+   *         
+   *         var jobs = tab.jobs({command:'ls -l /'});
+   *         for (var i = 0; i < jobs.length; i++) {
+   *             console.log(jobs[i].render());
+   *         }
+   *     });
+   *
+   * @return {String}
+   */
+  this.render = function() {
+    var time = this.when();
     
     var result = time + ' ' + command.toString();
     if (comment.toString() != '') {
@@ -1348,6 +1353,10 @@ function getVals() {
 // public API
 module.exports = {
   load: function(o, fn) {
+    if (typeof o === 'function') {
+      fn = o;
+      o = null;
+    }
     new CronTab(o, fn);
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ const SINFO = [
 /**
  * @ignore
  */
-var Spawn = require('child_process').spawn;
+var SPAWN = require('child_process').spawn;
 var _     = require('underscore');
 
 /**
@@ -55,10 +55,7 @@ var _     = require('underscore');
 function CronTab(u, cb) {
   var self   = this;
   var user   = typeof u === 'object' ? u && u.user : u || '';
-  var root   = (process.getuid() == 0);
-  var sudo   = typeof u === 'object' ? u && u.sudo : false;
-  var MYCMD  = sudo ? 'sudo' : COMMAND;
-  var MYARGV = sudo ? ['--'] : [];
+  var Spawn  = typeof u === 'object' ? u.spawn : SPAWN;
   var backup = {lines:[], jobs:[]};
   var lines  = [];
   var jobs   = [];
@@ -140,7 +137,7 @@ function CronTab(u, cb) {
     var stdout = '';
     var stderr = '';
     var args   = makeChildArgs('save');
-    var child  = Spawn(MYCMD, args);
+    var child  = Spawn(COMMAND, args);
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -315,7 +312,7 @@ function CronTab(u, cb) {
     var stdout = '';
     var stderr = '';
     var args   = makeChildArgs('load');
-    var child  = Spawn(MYCMD, args);
+    var child  = Spawn(COMMAND, args);
     
     jobs  = [];
     lines = [];
@@ -404,7 +401,7 @@ function CronTab(u, cb) {
       args = ['-u', user].concat(args);
     }
     
-    return MYARGV.concat(args);
+    return args; 
   }
   /**
    * Creates a new job. This method exists to catch possible exceptions thrown between

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,13 +49,16 @@ var _     = require('underscore');
  *         console.log("current user's tab: " + tab.render());
  *     });
  * 
- * @param {String} __username__
+ * @param {String|Object} __options__ - either a string for a username or an object like {user='',sudo=false}
  * @param {Function} __callback__
  */
 function CronTab(u, cb) {
   var self   = this;
-  var user   = u || '';
+  var user   = typeof u === 'object' ? u && u.user : u || '';
   var root   = (process.getuid() == 0);
+  var sudo   = typeof u === 'object' ? u && u.sudo : false;
+  var MYCMD  = sudo ? 'sudo' : COMMAND;
+  var MYARGV = sudo ? ['--'] : [];
   var backup = {lines:[], jobs:[]};
   var lines  = [];
   var jobs   = [];
@@ -137,7 +140,7 @@ function CronTab(u, cb) {
     var stdout = '';
     var stderr = '';
     var args   = makeChildArgs('save');
-    var child  = Spawn(COMMAND, args);
+    var child  = Spawn(MYCMD, args);
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -312,7 +315,7 @@ function CronTab(u, cb) {
     var stdout = '';
     var stderr = '';
     var args   = makeChildArgs('load');
-    var child  = Spawn(COMMAND, args);
+    var child  = Spawn(MYCMD, args);
     
     jobs  = [];
     lines = [];
@@ -401,7 +404,7 @@ function CronTab(u, cb) {
       args = ['-u', user].concat(args);
     }
     
-    return args;
+    return MYARGV.concat(args);
   }
   /**
    * Creates a new job. This method exists to catch possible exceptions thrown between
@@ -1347,13 +1350,8 @@ function getVals() {
 
 // public API
 module.exports = {
-  load:function() {
-    if (_.isString(arguments[0]) && _.isFunction(arguments[1])) {
-      new CronTab(arguments[0], arguments[1]);
-    }
-    else if (_.isFunction(arguments[0])) {
-      new CronTab('', arguments[0]);
-    }
+  load: function(o, fn) {
+    new CronTab(o, fn);
   }
 };
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -161,7 +161,12 @@ var rootLoadsAnoterUserCrons = {
 var sudoLoadsAnoterUserCrons = {
   'sudo user loads another (existing) user\'s crons': {
     topic: function() {
-      return loadTabs({user:'bob',sudo:true});
+      return loadTabs({
+        user:'bob',
+        spawn: function (cmd, argv, opt) {
+          return mockChild('sudo', ['--', cmd].concat(argv), opt);
+        }
+      });
     },
     'should succeed loading':function(err, tab) {
       sudoLoadsAnoterUserCrons.tab = tab;

--- a/test/runner.js
+++ b/test/runner.js
@@ -9,6 +9,9 @@ function mockChild(command, args) {
   var uRegEx = /-u\s([^\s]+)/;
   var tokens = args.join(' ').match(uRegEx);
   var user   = tokens && tokens[1] || '';
+  if (command === 'sudo') {
+    mockChild.user = 'root';
+  }
   
   function load(child) {
     process.nextTick(function() {
@@ -147,6 +150,21 @@ var rootLoadsAnoterUserCrons = {
     },
     'should succeed loading':function(err, tab) {
       rootLoadsAnoterUserCrons.tab = tab;
+      
+      Assert.isNull(err);
+      Assert.isObject(tab);
+      Assert.isArray(tab.jobs());
+      Assert.equal(tab.jobs().length, 3);
+    }
+  }
+};
+var sudoLoadsAnoterUserCrons = {
+  'sudo user loads another (existing) user\'s crons': {
+    topic: function() {
+      return loadTabs({user:'bob',sudo:true});
+    },
+    'should succeed loading':function(err, tab) {
+      sudoLoadsAnoterUserCrons.tab = tab;
       
       Assert.isNull(err);
       Assert.isObject(tab);
@@ -603,6 +621,7 @@ var CronTab = require('../lib/index');
 Vows.describe('crontab').
   addBatch(nonRootLoadsAnoterUserCrons).
   addBatch(rootLoadsAnoterUserCrons).
+  addBatch(sudoLoadsAnoterUserCrons).
   addBatch(rootLoadsAnoterNonExistingUserCrons).
   addBatch(userLoadsHisOwnEmptyCrons).
   addBatch(userLoadsHerOwnNonEmptyCrons).


### PR DESCRIPTION
this makes using sudoers work well with node-crontab by placing the user argument first always