### PR TITLE
Fixed invalid syntax for creating a cron job returning null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,7 +212,7 @@ function CronTab(u, cb) {
    */
   this.create = function(command, when, comment) {
     if (when && !_.isString(when) && !_.isDate(when)) {
-      return null;
+      throw {message:'Invalid when value: ' + when}; ;
     }
 
     command = (command || '').trim();
@@ -437,11 +437,7 @@ function CronTab(u, cb) {
    * @api private
    */
   function makeJob(line, command, comment) {
-    try {
-      return new CronJob(line, command, comment);
-    } catch(e) {}
-    
-    return null;
+    return new CronJob(line, command, comment);
   }
   /**
    * Compacts the line collection by removes empty lines from the end.
@@ -541,7 +537,6 @@ function CronJob(line, c, m) {
     if (timeIdx >=0 ) {
       time = '@' + keys[timeIdx];
     }
-    
     var result = time + ' ' + command.toString();
     if (comment.toString() != '') {
       result += ' #' + comment.toString();
@@ -754,7 +749,7 @@ function CronJob(line, c, m) {
    */
   function init() {
     setSlots();
-    
+
     if (line) {
       var result = line.match(ITEMREX);
       
@@ -780,7 +775,10 @@ function CronJob(line, c, m) {
               setSlots(value.split(' '));
             }
             valid = true;
+            return;
         }
+
+        throw new Error('Invalid cron syntax. Use either a string expression, a date, or a special');
       }
     }
     else if (c) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -288,6 +288,11 @@ var canCreateJob = {
 
       return loadTabs('');
     },
+    'should error with invalid cron syntax':function(err, tab) {
+      Assert.throws(function() {
+        var job = tab.create('ls -l', 'blah', 'test');
+      }, Error);
+    },
     'should succeed with string expression and comment':function(err, tab) {
       var job = tab.create('ls -l', '0 7 * * 1,2,3,4,5', 'test');
 


### PR DESCRIPTION
When creating a cronjob with an invalid syntax, it used to just return null, so a user wouldn't know why the cron job was not created.

I've modified this so it now throws an error when there is an invalid cronjob trying to be created so the user knows what the issue is.