### PR TITLE
Delete confirmation and Pause functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,12 +32,13 @@ var CronJob = require('./CronJob');
  * @param {Function} __callback__
  */
 function CronTab(u, cb) {
-  var self   = this;
-  var user   = u || '';
-  var root   = (process.getuid() == 0);
-  var backup = {lines:[], jobs:[]};
-  var lines  = [];
-  var jobs   = [];
+  var self       = this;
+  var user       = u || '';
+  var root       = (process.getuid() == 0);
+  var backup     = {lines:[], jobs:[]};
+  var lines      = [];
+  var jobs       = [];
+  var pausedFlag = '#paused'
 
   load(cb);
 
@@ -283,6 +284,101 @@ function CronTab(u, cb) {
     jobs  = backup.jobs.slice();
   }
 
+  /**
+   * Returns all paused jobs
+   * This uses the `#paused` flag to determine which comemnts are paused jobs
+   *
+   * Examples:
+   *     new CronTab(function(err, tab) {
+   *         if (err) { console.log(err); process.exit(1); }
+   *
+   *         var jobs = tab.pausedJobsjobs(;
+   *     });
+   *
+   * @param {Object} __[options]__
+   * @return {Array[CronJob]}
+   */
+  this.pausedJobs = function() {
+    // This flag identifies 'paused' jobs in the crontab
+    const pausedTokens = [];
+    const pausedJobs = [];
+
+    lines.forEach((line) => {
+      if (typeof line === 'string') {
+        let trimmed = line.substring(0, pausedFlag.length);
+        if (trimmed === pausedFlag) {
+          pausedTokens.push(
+            line.slice(pausedFlag.length)
+          );
+        }
+      }
+    });
+
+    if (pausedTokens.length === 0) {
+      return [];
+    }
+
+    pausedTokens.forEach((token) => {
+      const job = makeJob(token);
+      if (job !== null && job.isValid()) {
+        pausedJobs.push(job);
+      }
+    });
+
+    return pausedJobs;
+  }
+  /**
+   * Pause a job
+   *
+   * @param {CronJob}
+   * @return {Boolean}
+   */
+  this.pauseJob = function(job) {
+    if (!job.isValid()) {
+      return false;
+    }
+
+    const command = job.command();
+    const removeTask = remove(job);
+
+    if (removeTask) {
+      const pausedEntry = `${pausedFlag}${job.toString()}`;
+      lines.push(pausedEntry);
+      return true;
+    }
+
+    return false;
+  }
+  /**
+   * Activate a job
+   *
+   * @param {CronJob}
+   * @return {Boolean}
+   */
+  this.activateJob = function(job) {
+    let targetIndex;
+    lines.forEach((line, index) => {
+      if (typeof line === 'string') {
+        const trimmed = line.substring(0, pausedFlag.length);
+        const command = line.slice(pausedFlag.length);
+        // Is this a paused job and does it match
+        if (trimmed === pausedFlag && command === job.toString()) {
+          targetIndex = index;
+        }
+      }
+    });
+
+    // Remove the paused job by index
+    lines.splice(targetIndex, 1);
+    const activeJob = makeJob(job.toString());
+    if (activeJob && activeJob.isValid()) {
+      // Re-add active, valid job into lines array
+      lines.push(activeJob);
+      return true;
+    }
+
+    return false;
+  }
 
   /**
    * Loads the system crontab into this object.
@@ -425,7 +521,6 @@ function CronTab(u, cb) {
       if (!job || !job.isValid()) {
         throw 'invalid job';
       }
-
       return job;
     } catch(e) {}
 
@@ -454,6 +549,8 @@ function CronTab(u, cb) {
 // public API
 module.exports = {
   load:function() {
+    console.log('Using linked module');
+
     if (_.isString(arguments[0]) && _.isFunction(arguments[1])) {
       new CronTab(arguments[0], arguments[1]);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Constants
  */
-const COMMAND = 'crontab';
+var COMMAND = 'crontab';
 
 /**
  * @ignore
@@ -300,12 +300,12 @@ function CronTab(u, cb) {
    */
   this.pausedJobs = function() {
     // This flag identifies 'paused' jobs in the crontab
-    const pausedTokens = [];
-    const pausedJobs = [];
+    var pausedTokens = [];
+    var pausedJobs = [];
 
-    lines.forEach((line) => {
+    lines.forEach(function(line) {
       if (typeof line === 'string') {
-        let trimmed = line.substring(0, pausedFlag.length);
+        var trimmed = line.substring(0, pausedFlag.length);
         if (trimmed === pausedFlag) {
           pausedTokens.push(
             line.slice(pausedFlag.length)
@@ -318,8 +318,8 @@ function CronTab(u, cb) {
       return [];
     }
 
-    pausedTokens.forEach((token) => {
-      const job = makeJob(token);
+    pausedTokens.forEach(function(token) {
+      var job = makeJob(token);
       if (job !== null && job.isValid()) {
         pausedJobs.push(job);
       }
@@ -338,11 +338,11 @@ function CronTab(u, cb) {
       return false;
     }
 
-    const command = job.command();
-    const removeTask = remove(job);
+    var command = job.command();
+    var removeTask = remove(job);
 
     if (removeTask) {
-      const pausedEntry = `${pausedFlag}${job.toString()}`;
+      var pausedEntry = pausedFlag + job.toString();
       lines.push(pausedEntry);
       return true;
     }
@@ -356,11 +356,11 @@ function CronTab(u, cb) {
    * @return {Boolean}
    */
   this.activateJob = function(job) {
-    let targetIndex;
-    lines.forEach((line, index) => {
+    var targetIndex;
+    lines.forEach(function(line, index) {
       if (typeof line === 'string') {
-        const trimmed = line.substring(0, pausedFlag.length);
-        const command = line.slice(pausedFlag.length);
+        var trimmed = line.substring(0, pausedFlag.length);
+        var command = line.slice(pausedFlag.length);
         // Is this a paused job and does it match
         if (trimmed === pausedFlag && command === job.toString()) {
           targetIndex = index;
@@ -370,7 +370,7 @@ function CronTab(u, cb) {
 
     // Remove the paused job by index
     lines.splice(targetIndex, 1);
-    const activeJob = makeJob(job.toString());
+    var activeJob = makeJob(job.toString());
     if (activeJob && activeJob.isValid()) {
       // Re-add active, valid job into lines array
       lines.push(activeJob);

--- a/lib/index.js
+++ b/lib/index.js
@@ -549,8 +549,6 @@ function CronTab(u, cb) {
 // public API
 module.exports = {
   load:function() {
-    console.log('Using linked module');
-
     if (_.isString(arguments[0]) && _.isFunction(arguments[1])) {
       new CronTab(arguments[0], arguments[1]);
     }


### PR DESCRIPTION
Had use for a pause functionality and didn't want to have to go the route of a separate data store. This adds a `pausedJobs` method to retrieve all paused jobs and a `pauseJob` method to pause a single job based on command.

Also added in a confirmation on delete if a job was successfully removed. 

Using this in a [separate app](https://github.com/ktsosno/cronbuddy-server) to create REST resources for the crontab.