### PR TITLE
Add support for environment variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,9 +35,10 @@ function CronTab(u, cb) {
   var self   = this;
   var user   = u || '';
   var root   = (process.getuid() == 0);
-  var backup = {lines:[], jobs:[]};
+  var backup = {lines:[], jobs:[], env:{}};
   var lines  = [];
   var jobs   = [];
+  this.env   = {};
   
   load(cb);
   
@@ -157,6 +158,10 @@ function CronTab(u, cb) {
   this.render = function() {
     var tokens = [];
     
+    var envvars = _.pairs(this.env).map(function(envvar) {
+      return envvar[0] + '=' + envvar[1];
+    });
+
     for (var i = 0; i < lines.length; i++) {
       var job = lines[i];
       
@@ -168,7 +173,7 @@ function CronTab(u, cb) {
       tokens.push(job.toString());
     }
     
-    return tokens.join('\n').trim() + '\n';
+    return envvars.join('\n') + '\n\n' + tokens.join('\n').trim() + '\n';
   }
   /**
    * Creates a new job with the specified command, comment and date.
@@ -277,6 +282,7 @@ function CronTab(u, cb) {
   this.reset = function() {
     lines = backup.lines.slice();
     jobs  = backup.jobs.slice();
+    this.env = _.clone(backup.env);
   }
   
   
@@ -324,7 +330,13 @@ function CronTab(u, cb) {
           lines.push(job);
         }
         else {
-          lines.push(token);
+
+          var envvar = token.match(/^(\S*)=(.*)$/);
+          if (envvar != null && envvar[2]) {
+            self.env[envvar[1]] = envvar[2];
+          } else {
+            lines.push(token);
+          }
         }
       }
       
@@ -332,6 +344,7 @@ function CronTab(u, cb) {
       
       backup.lines = lines.slice();
       backup.jobs  = jobs.slice();
+      backup.env   = _.clone(self.env);
       
       cb && cb(null, self); 
     });

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "version": "1.1.3",
   "main": "./lib/index",
   "dependencies": {
-    "underscore": "^1.6.0"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "vows": "0.7.0"
+    "vows": "0.8.1"
   },
   "scripts": {
     "test": "test/runner.js"


### PR DESCRIPTION
Adds support (with test) for reading/writing environment variables within crontabs.  Also resets variables when `reset` is called.

crontab:
```
FOO=bar
LIBS_DIR=/some/lib/dir

*/10 * * * * /usr/bin/something
```

```javascript
require('crontab').load((err, crontab) => {
  console.log(crontab.env);
  // { FOO: 'bar', LIBS_DIR: '/some/lib/dir' }
});
```

```javascript
delete crontab.env.FOO;
crontab.env.LIBS_DIR='/some/other/lib/dir'
crontab.env.BAR = 'okay';

console.log(crontab.render());
```

```
LIBS_DIR=/some/other/lib/dir
BAR=okay

*/10 * * * * /usr/bin/something
```